### PR TITLE
Fix imports for attachment endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,9 @@
 from fastapi import FastAPI, Query, Header, HTTPException, Depends
+from fastapi.responses import StreamingResponse
 from email import message_from_bytes
+from email.policy import default as default_policy
+import io
+import zipfile
 
 import imaplib
 import os


### PR DESCRIPTION
## Summary
- add missing imports for attachments endpoint

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aef21c10c832786096cef89b0698b